### PR TITLE
feat: update HTTP server metric collection and dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,20 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.6"
 dynamic = ["version"]
 dependencies = [
-    "opentelemetry-util-http == 0.54b1",
-    "opentelemetry-instrumentation == 0.54b1",
-    "opentelemetry-instrumentation-wsgi == 0.54b1",
+    "opentelemetry-util-http == 0.57b0",
+    "opentelemetry-instrumentation == 0.57b0",
+    "opentelemetry-instrumentation-wsgi == 0.57b0",
     "opentelemetry-api ~= 1.12",
-    "opentelemetry-semantic-conventions == 0.54b1"
+    "opentelemetry-semantic-conventions == 0.57b0"
 ]
 
 [project.optional-dependencies]
@@ -38,7 +39,7 @@ instruments = [
 ]
 test = [
     "opentelemetry-instrumentation-simplerr[instruments]",
-    "opentelemetry-test-utils == 0.54b1",
+    "opentelemetry-test-utils == 0.57b0",
 ]
 
 [project.entry-points."opentelemetry_instrumentor"]

--- a/src/opentelemetry/instrumentation/simplerr/__init__.py
+++ b/src/opentelemetry/instrumentation/simplerr/__init__.py
@@ -17,7 +17,7 @@ from opentelemetry.instrumentation._semconv import (
     _get_schema_url,
     _report_old,
     _report_new,
-    _StabilityMode
+    _StabilityMode, HTTP_DURATION_HISTOGRAM_BUCKETS_NEW
 )
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.simplerr.package import _instruments
@@ -203,6 +203,7 @@ class _InstrumentedWsgi(simplerr.dispatcher.wsgi):
                 name=HTTP_SERVER_REQUEST_DURATION,
                 unit="s",
                 description="Duration of HTTP server requests.",
+                explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW
             )
 
         active_request_counter = meter.create_up_down_counter(
@@ -304,6 +305,7 @@ class SimplerrInstrumentor(BaseInstrumentor):
                     name=HTTP_SERVER_REQUEST_DURATION,
                     unit="s",
                     description="Duration of HTTP server requests.",
+                    explicit_bucket_boundaries_advisory=HTTP_DURATION_HISTOGRAM_BUCKETS_NEW
                 )
 
             active_request_counter = meter.create_up_down_counter(

--- a/src/opentelemetry/instrumentation/simplerr/version.py
+++ b/src/opentelemetry/instrumentation/simplerr/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.54b1"
+__version__ = "0.57b0.dev1"


### PR DESCRIPTION
- Add histogram explicit bucket boundaries to HTTP server request duration metric.
- Enhance `_assert_basic_metric` test helper to validate histogram bounds.
- Update dependencies to version 0.57b0.
- Add support for Python 3.12 and 3.13 in `pyproject.toml`.
- Bump package version to 0.57b0.dev1.